### PR TITLE
pass options to bootstrap modal

### DIFF
--- a/addon/components/modal-manager.js
+++ b/addon/components/modal-manager.js
@@ -8,6 +8,8 @@ const a = Ember.A; // jshint ignore:line
 export default Ember.Component.extend({
   layout: layout,
   containerClass: 'modal-lg',
+  modalOptions: {},
+  // keyboard setting is NOT supported - cannot exit modal by pressing ESC
 
   modal:inject.service(),
 

--- a/addon/components/modal-wrapper.js
+++ b/addon/components/modal-wrapper.js
@@ -12,10 +12,10 @@ export default Ember.Component.extend({
 
 
   show: on('didInsertElement', function() {
-    this.$('.modal').modal();
+    this.$('.modal').modal(this.get('modalOptions'));
   }),
 
-  
+
   close:function(){
     this.$('.modal').modal('hide');
   },

--- a/addon/templates/components/modal-manager.hbs
+++ b/addon/templates/components/modal-manager.hbs
@@ -4,5 +4,6 @@
 		onCloseResolve="closeModalResolve"
 		onCloseReject="closeModalReject"
 		containerClass=containerClass
+    modalOptions=modalOptions
 	}}
 {{/each}}


### PR DESCRIPTION
Allow the modal-manager component to be passed options that it will in turn pass directly to Bootstrap's modal.